### PR TITLE
Implement API proxy

### DIFF
--- a/src/server.spec.ts
+++ b/src/server.spec.ts
@@ -1,0 +1,42 @@
+import { app } from './server';
+import { AddressInfo } from 'net';
+import http from 'node:http';
+
+describe('API proxy', () => {
+  let server: http.Server;
+  let port: number;
+
+  beforeEach(() => {
+    server = app.listen(0);
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
+  it('forwards requests to the Rick and Morty API', async () => {
+    const mockData = { success: true };
+    const fetchSpy = jest
+      .spyOn(global, 'fetch' as any)
+      .mockResolvedValue(
+        new Response(JSON.stringify(mockData), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }) as any,
+      );
+
+    const result = await new Promise<{ status?: number; body: string }>((resolve, reject) => {
+      http.get(`http://127.0.0.1:${port}/api/character`, res => {
+        let data = '';
+        res.on('data', chunk => (data += chunk));
+        res.on('end', () => resolve({ status: res.statusCode, body: data }));
+      }).on('error', reject);
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith('https://rickandmortyapi.com/api/character');
+    expect(result.status).toBe(200);
+    expect(result.body).toBe(JSON.stringify(mockData));
+    fetchSpy.mockRestore();
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,8 @@ import {
 import express from 'express';
 import { join } from 'node:path';
 
+const API_BASE_URL = 'https://rickandmortyapi.com';
+
 const browserDistFolder = join(import.meta.dirname, '../browser');
 
 const app = express();
@@ -23,6 +25,25 @@ const angularApp = new AngularNodeAppEngine();
  * });
  * ```
  */
+
+/**
+ * Proxy Rick and Morty API requests through this server.
+ */
+app.use('/api', async (req, res, next) => {
+  try {
+    const url = API_BASE_URL + req.originalUrl;
+    const response = await fetch(url);
+    const body = await response.text();
+    res.status(response.status);
+    const contentType = response.headers.get('content-type');
+    if (contentType) {
+      res.set('Content-Type', contentType);
+    }
+    res.send(body);
+  } catch (error) {
+    next(error);
+  }
+});
 
 /**
  * Serve static files from /browser
@@ -66,3 +87,5 @@ if (isMainModule(import.meta.url)) {
  * Request handler used by the Angular CLI (for dev-server and during build) or Firebase Cloud Functions.
  */
 export const reqHandler = createNodeRequestHandler(app);
+
+export { app };

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -5,7 +5,8 @@
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
     "types": [
-      "jasmine"
+      "jasmine",
+      "node"
     ]
   },
   "include": [


### PR DESCRIPTION
## Summary
- add Rick and Morty API proxy middleware
- expose Express `app` for testing
- allow Node types in `tsconfig.spec.json`
- test server proxy behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841472fd9d4832cbf46ab7bc3b4887e