### PR TITLE
Add basic character listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,26 @@ Angular CLI does not come with an end-to-end testing framework by default. You c
 ## Additional Resources
 
 For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
+
+## Installation
+
+Install dependencies with npm:
+
+```bash
+npm install
+```
+
+## Running Tests
+
+Execute unit tests with Jest:
+
+```bash
+npm test
+```
+
+This project requires at least 80% coverage as configured in `jest.config.js`.
+
+## Features
+
+- Angular standalone component displaying a list of characters from the [Rick and Morty API](https://rickandmortyapi.com/).
+- State management using Angular Signals.

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,6 @@
 import { Routes } from '@angular/router';
+import { CharacterListComponent } from './characters/character-list.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: '', component: CharacterListComponent },
+];

--- a/src/app/characters/character-list.component.spec.ts
+++ b/src/app/characters/character-list.component.spec.ts
@@ -1,0 +1,34 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { RickAndMortyService } from './rick-and-morty.service';
+import { CharacterListComponent } from './character-list.component';
+import { of } from 'rxjs';
+
+describe('CharacterListComponent', () => {
+  let component: CharacterListComponent;
+  let fixture: ComponentFixture<CharacterListComponent>;
+  let service: RickAndMortyService;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, CharacterListComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CharacterListComponent);
+    component = fixture.componentInstance;
+    service = TestBed.inject(RickAndMortyService);
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display characters', () => {
+    service.characters.set([{ id: 1, name: 'Morty', status: '', species: 'Human', image: '' }]);
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Morty');
+  });
+});

--- a/src/app/characters/character-list.component.ts
+++ b/src/app/characters/character-list.component.ts
@@ -1,0 +1,25 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RickAndMortyService } from './rick-and-morty.service';
+
+@Component({
+  selector: 'app-character-list',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <h2>Characters</h2>
+    <button (click)="service.loadCharacters()">Load</button>
+    <ul>
+      <li *ngFor="let char of service.characters()">
+        <img [src]="char.image" width="50" /> {{ char.name }} - {{ char.species }}
+      </li>
+    </ul>
+  `,
+})
+export class CharacterListComponent implements OnInit {
+  constructor(public service: RickAndMortyService) {}
+
+  ngOnInit() {
+    this.service.loadCharacters();
+  }
+}

--- a/src/app/characters/character.model.ts
+++ b/src/app/characters/character.model.ts
@@ -1,0 +1,7 @@
+export interface Character {
+  id: number;
+  name: string;
+  status: string;
+  species: string;
+  image: string;
+}

--- a/src/app/characters/rick-and-morty.service.spec.ts
+++ b/src/app/characters/rick-and-morty.service.spec.ts
@@ -1,0 +1,31 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { RickAndMortyService } from './rick-and-morty.service';
+import { Character } from './character.model';
+
+describe('RickAndMortyService', () => {
+  let service: RickAndMortyService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [RickAndMortyService],
+    });
+    service = TestBed.inject(RickAndMortyService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  it('should load characters', () => {
+    const mockCharacters: Character[] = [
+      { id: 1, name: 'Rick', status: 'Alive', species: 'Human', image: '' },
+    ];
+
+    service.loadCharacters();
+
+    const req = httpMock.expectOne('https://rickandmortyapi.com/api/character');
+    req.flush({ results: mockCharacters });
+
+    expect(service.characters()).toEqual(mockCharacters);
+  });
+});

--- a/src/app/characters/rick-and-morty.service.ts
+++ b/src/app/characters/rick-and-morty.service.ts
@@ -1,0 +1,17 @@
+import { Injectable, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Character } from './character.model';
+
+@Injectable({ providedIn: 'root' })
+export class RickAndMortyService {
+  private readonly baseUrl = 'https://rickandmortyapi.com/api';
+  characters = signal<Character[]>([]);
+
+  constructor(private http: HttpClient) {}
+
+  loadCharacters() {
+    this.http
+      .get<{ results: Character[] }>(`${this.baseUrl}/character`)
+      .subscribe(({ results }) => this.characters.set(results));
+  }
+}


### PR DESCRIPTION
## Summary
- add a simple standalone component that lists Rick and Morty characters
- provide a service using Signals to store characters
- wire the component via router
- document installation and tests in README
- add Jest unit tests for the service and component

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841463398a8832c9d1c9286099bf2c6