### PR TITLE
Fix service spec conflict

### DIFF
--- a/src/app/core/services/rick-and-morty.service.spec.ts
+++ b/src/app/core/services/rick-and-morty.service.spec.ts
@@ -1,12 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-<<<<<<<< HEAD:src/app/personagens/rick-and-morty.servico.spec.ts
 import { RickAndMortyServico } from './rick-and-morty.servico';
 import { Personagem } from './personagem.model';
-========
-import { RickAndMortyService } from './rick-and-morty.service';
-import { Character } from '../models/character.model';
->>>>>>>> main:src/app/core/services/rick-and-morty.service.spec.ts
 
 describe('RickAndMortyServico', () => {
   let service: RickAndMortyServico;

--- a/src/app/personagens/rick-and-morty.servico.spec.ts
+++ b/src/app/personagens/rick-and-morty.servico.spec.ts
@@ -1,12 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-<<<<<<<< HEAD:src/app/personagens/rick-and-morty.servico.spec.ts
 import { RickAndMortyServico } from './rick-and-morty.servico';
 import { Personagem } from './personagem.model';
-========
-import { RickAndMortyService } from './rick-and-morty.service';
-import { Character } from '../models/character.model';
->>>>>>>> main:src/app/core/services/rick-and-morty.service.spec.ts
 
 describe('RickAndMortyServico', () => {
   let service: RickAndMortyServico;


### PR DESCRIPTION
## Summary
- remove leftover merge markers from service tests

## Testing
- `npx jest --coverage` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68414e8abf80832c8e5dfa080e880982