### PR TITLE
Add combined start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ json-server --watch db.json --port 3000
 npm start
 ```
 
+To run the API and Angular application together, use:
+
+```bash
+npm run start:dev
+```
+
 ## Code scaffolding
 
 Angular CLI includes powerful code scaffolding tools. To generate a new component, run:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.conf.json",
+    "start:api": "json-server --watch db.json --port 3000",
+    "start:dev": "concurrently \"npm run start:api\" \"npm start\"",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "jest --coverage",
@@ -44,5 +46,7 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "ts-jest": "^29.3.4",
     "typescript": "~5.8.2"
+    ,"concurrently": "^8.2.2"
+    ,"json-server": "^0.17.4"
   }
 }


### PR DESCRIPTION
## Summary
- run the API and Angular app together with `npm run start:dev`
- document how to launch both servers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b22593e0832cab4b5bc02928a7a8