### PR TITLE
Fix Jest config for ES2020

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,11 @@ module.exports = {
   preset: 'jest-preset-angular',
   setupFilesAfterEnv: ['<rootDir>/setup-jest.ts'],
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
-  globals: {},
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
   transform: {
     '^.+\\.(ts|js|html)$': 'ts-jest',
   },

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -7,7 +7,9 @@
     "types": [
       "jasmine",
       "node"
-    ]
+    ],
+    "module": "commonjs",
+    "target": "ES2020"
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
## Summary
- tweak tsconfig for Jest to compile to commonjs ES2020
- specify `ts-jest` config in Jest setup

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b280eea4832c8cb1c130879ac2ef