### PR TITLE
Fix jest config with preset transform

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,13 +2,11 @@ module.exports = {
   preset: 'jest-preset-angular',
   setupFilesAfterEnv: ['<rootDir>/setup-jest.ts'],
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-    },
-  },
   transform: {
-    '^.+\\.(ts|js|html)$': 'ts-jest',
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular/build/transform',
+      { tsconfig: '<rootDir>/tsconfig.spec.json' },
+    ],
   },
   testEnvironment: 'jsdom',
   moduleFileExtensions: ['ts', 'html', 'js', 'json'],


### PR DESCRIPTION
## Summary
- update Jest configuration to use `jest-preset-angular` transform

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b44f2d20832ca41889598e89409b