### PR TITLE
Fix docs for Jest and zone.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ Install dependencies with npm:
 npm install
 ```
 
+Ensure `zone.js` is installed, as Jest relies on it for Angular testing. If it
+is missing, install it with:
+
+```bash
+npm install zone.js
+```
+
 ## Running Tests
 
 Execute unit tests with Jest:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "@angular/ssr": "^20.0.1",
     "express": "^5.1.0",
     "rxjs": "~7.8.0",
-    "tslib": "^2.3.0"
+    "tslib": "^2.3.0",
+    "zone.js": "~0.15.0"
   },
   "devDependencies": {
     "@angular/build": "^20.0.1",


### PR DESCRIPTION
## Summary
- document zone.js dependency for Jest
- add zone.js to package.json

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841eaa9b9c0832cb573f507a766616f