### PR TITLE
Add character list on home screen

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,1 +1,1 @@
-<p>home works!</p>
+<app-lista-personagens></app-lista-personagens>

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -20,4 +20,9 @@ describe('HomeComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should render lista de personagens', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Personagens');
+  });
 });

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,8 +1,10 @@
 import { Component } from '@angular/core';
+import { ListaPersonagensComponent } from '../personagens/lista-personagens.component';
 
 @Component({
   selector: 'app-home',
   standalone: true,
+  imports: [ListaPersonagensComponent],
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss'],
 })

--- a/src/app/personagens/detalhe-personagem.component.html
+++ b/src/app/personagens/detalhe-personagem.component.html
@@ -7,5 +7,11 @@
   <p *ngIf="p.gender">Gender: {{ p.gender }}</p>
   <p *ngIf="p.origin">Origin: {{ p.origin?.name }}</p>
   <p *ngIf="p.location">Location: {{ p.location?.name }}</p>
+  <div *ngIf="p.episode?.length">
+    Episódios:
+    <ul>
+      <li *ngFor="let ep of p.episode">{{ ep }}</li>
+    </ul>
+  </div>
   <a routerLink="/personagens">Voltar</a>
 </ng-container>

--- a/src/app/personagens/lista-personagens.component.html
+++ b/src/app/personagens/lista-personagens.component.html
@@ -3,37 +3,21 @@
 <input type="text" [formControl]="busca" placeholder="Buscar" />
 <button (click)="servico.carregarPersonagens()">Carregar</button>
 
-<ul>
-  <li *ngFor="let personagem of servico.todos()">
-    <a [routerLink]="['/personagem', personagem.id]">
-      <img [src]="personagem.image" width="50" />
-      {{ personagem.name }} - {{ personagem.species }}
-    </a>
-    <button
-      *ngIf="personagem.id >= 10000"
-      (click)="editar(personagem.id)"
-    >
-      Editar
-    </button>
-    <button
-      *ngIf="personagem.id >= 10000"
-      (click)="excluir(personagem.id)"
-    >
-      Excluir
-    </button>
-  </li>
-</ul>
-
 <mat-grid-list [cols]="cols" gutterSize="16">
   <mat-grid-tile *ngFor="let personagem of servico.todos()">
-    <mat-card class="personagem-card">
+    <mat-card
+      class="personagem-card"
+      [routerLink]="['/personagem', personagem.id]"
+    >
       <img mat-card-image [src]="personagem.image" [alt]="personagem.name" />
       <mat-card-title>{{ personagem.name }}</mat-card-title>
+      <mat-card-subtitle>{{ personagem.status }}</mat-card-subtitle>
       <mat-card-content>{{ personagem.species }}</mat-card-content>
       <button
         mat-button
         color="primary"
         [routerLink]="['/editar', personagem.id]"
+        (click)="$event.stopPropagation()"
         *ngIf="personagem.id >= 10000"
       >
         Editar
@@ -42,7 +26,7 @@
         mat-button
         color="warn"
         *ngIf="personagem.id >= 10000"
-        (click)="excluir(personagem.id)"
+        (click)="excluir(personagem.id); $event.stopPropagation()"
       >
         Excluir
       </button>

--- a/src/app/personagens/lista-personagens.component.scss
+++ b/src/app/personagens/lista-personagens.component.scss
@@ -1,3 +1,4 @@
 .personagem-card {
   text-align: center;
+  cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- show character list on the home page
- make character cards link to detail page
- display status on each card
- list episodes on the detail page
- add unit test for home component

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f2894260832cbbfc5f35dca139d5