### PR TITLE
Add dialog expansion for character cards

### DIFF
--- a/src/app/personagens/lista-personagens.component.html
+++ b/src/app/personagens/lista-personagens.component.html
@@ -7,7 +7,7 @@
   <mat-grid-tile *ngFor="let personagem of servico.todos()">
     <mat-card
       class="personagem-card"
-      [routerLink]="['/personagem', personagem.id]"
+      (click)="abrirDetalhe(personagem)"
     >
       <img mat-card-image [src]="personagem.image" [alt]="personagem.name" />
       <mat-card-title>{{ personagem.name }}</mat-card-title>

--- a/src/app/personagens/lista-personagens.component.ts
+++ b/src/app/personagens/lista-personagens.component.ts
@@ -7,6 +7,9 @@ import { MatCardModule } from '@angular/material/card';
 import { MatGridListModule } from '@angular/material/grid-list';
 import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { MatButtonModule } from '@angular/material/button';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { PersonagemDialogComponent } from './personagem-dialog.component';
+import { Personagem } from './personagem.model';
 
 import { RickAndMortyServico } from './rick-and-morty.servico';
 
@@ -22,6 +25,8 @@ import { RickAndMortyServico } from './rick-and-morty.servico';
     MatGridListModule,
     MatPaginatorModule,
     MatButtonModule,
+    MatDialogModule,
+    PersonagemDialogComponent,
   ],
 
   templateUrl: './lista-personagens.component.html',
@@ -33,7 +38,11 @@ export class ListaPersonagensComponent implements OnInit {
 
   cols = 4;
 
-  constructor(public servico: RickAndMortyServico, private router: Router) {}
+  constructor(
+    public servico: RickAndMortyServico,
+    private router: Router,
+    private dialog: MatDialog
+  ) {}
 
   @HostListener('window:resize')
   onResize() {
@@ -61,6 +70,12 @@ export class ListaPersonagensComponent implements OnInit {
 
   onPage(event: PageEvent) {
     this.servico.carregarPersonagens(event.pageIndex + 1);
+  }
+
+  abrirDetalhe(personagem: Personagem) {
+    this.dialog.open(PersonagemDialogComponent, {
+      data: personagem,
+    });
   }
 
   editar(id: number) {

--- a/src/app/personagens/personagem-dialog.component.html
+++ b/src/app/personagens/personagem-dialog.component.html
@@ -1,0 +1,18 @@
+<mat-card class="detalhe-card">
+  <img mat-card-image [src]="data.image" [alt]="data.name" />
+  <mat-card-title>{{ data.name }}</mat-card-title>
+  <mat-card-content>
+    <p><strong>Status:</strong> {{ data.status }}</p>
+    <p><strong>Species:</strong> {{ data.species }}</p>
+    <p *ngIf="data.type"><strong>Type:</strong> {{ data.type }}</p>
+    <p *ngIf="data.gender"><strong>Gender:</strong> {{ data.gender }}</p>
+    <p *ngIf="data.origin"><strong>Origin:</strong> {{ data.origin?.name }}</p>
+    <p *ngIf="data.location"><strong>Location:</strong> {{ data.location?.name }}</p>
+    <p *ngIf="data.episode?.length"><strong>Episodes:</strong> {{ data.episode.join(', ') }}</p>
+    <p *ngIf="data.url"><strong>URL:</strong> {{ data.url }}</p>
+    <p *ngIf="data.created"><strong>Created:</strong> {{ data.created }}</p>
+  </mat-card-content>
+  <div class="actions">
+    <button mat-button mat-dialog-close>Fechar</button>
+  </div>
+</mat-card>

--- a/src/app/personagens/personagem-dialog.component.scss
+++ b/src/app/personagens/personagem-dialog.component.scss
@@ -1,0 +1,7 @@
+.detalhe-card {
+  max-width: 400px;
+}
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/src/app/personagens/personagem-dialog.component.ts
+++ b/src/app/personagens/personagem-dialog.component.ts
@@ -1,0 +1,19 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { Personagem } from './personagem.model';
+
+@Component({
+  selector: 'app-personagem-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  templateUrl: './personagem-dialog.component.html',
+  styleUrls: ['./personagem-dialog.component.scss'],
+})
+export class PersonagemDialogComponent {
+  constructor(
+    public dialogRef: MatDialogRef<PersonagemDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: Personagem
+  ) {}
+}


### PR DESCRIPTION
## Summary
- create `PersonagemDialogComponent` to display full character info
- open this dialog when a card is clicked in the list

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841fa42ba0c832c82b7649d65606b02