### PR TITLE
Improve character form dialog layout

### DIFF
--- a/src/app/personagens/form-personagem/form-personagem.component.scss
+++ b/src/app/personagens/form-personagem/form-personagem.component.scss
@@ -1,8 +1,8 @@
 form {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 1rem;
-  max-width: 400px;
+  max-width: 600px;
   margin: auto;
 }
 
@@ -11,15 +11,27 @@ form {
 }
 
 .preview {
-  max-width: 100%;
-  margin-top: 0.5rem;
+  max-width: 150px;
+  margin: 0.5rem auto;
+  grid-column: 1 / -1;
 }
 
 .actions {
   display: flex;
   gap: 0.5rem;
+  grid-column: 1 / -1;
 }
 
 .file-input {
   padding: 0.5rem 0;
+}
+
+div[ngswitch] {
+  grid-column: 1 / -1;
+}
+
+@media (max-width: 600px) {
+  form {
+    grid-template-columns: 1fr;
+  }
 }

--- a/src/app/shared/toolbar/toolbar.component.ts
+++ b/src/app/shared/toolbar/toolbar.component.ts
@@ -50,6 +50,10 @@ export class ToolbarComponent implements OnInit {
   }
 
   abrirNovo() {
-    this.dialog.open(FormPersonagemComponent, { width: '400px' });
+    this.dialog.open(FormPersonagemComponent, {
+      width: '90vw',
+      maxWidth: '600px',
+      maxHeight: '90vh',
+    });
   }
 }


### PR DESCRIPTION
## Summary
- improve dialog open options to fit viewport
- arrange character form in two columns
- shrink image preview

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684264cf9778832cb57277a5f841e413