### PR TITLE
Implement character blocking feature

### DIFF
--- a/db.json
+++ b/db.json
@@ -1,3 +1,4 @@
 {
-  "personagens": []
+  "personagens": [],
+  "bloqueados": []
 }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -3,6 +3,7 @@ import { ListaPersonagensComponent } from './personagens/lista-personagens/lista
 import { DetalhePersonagemComponent } from './personagens/detalhe-personagem/detalhe-personagem.component';
 import { FormPersonagemComponent } from './personagens/form-personagem/form-personagem.component';
 import { HomeComponent } from './home/home.component';
+import { ListaBloqueadosComponent } from './personagens/lista-bloqueados/lista-bloqueados.component';
 
 
 export const routes: Routes = [
@@ -11,4 +12,5 @@ export const routes: Routes = [
   { path: 'personagem/:id', component: DetalhePersonagemComponent },
   { path: 'novo', component: FormPersonagemComponent },
   { path: 'editar/:id', component: FormPersonagemComponent },
+  { path: 'bloqueados', component: ListaBloqueadosComponent },
 ];

--- a/src/app/personagens/lista-bloqueados/lista-bloqueados.component.html
+++ b/src/app/personagens/lista-bloqueados/lista-bloqueados.component.html
@@ -1,0 +1,18 @@
+<h2>Personagens Bloqueados</h2>
+<mat-grid-list [cols]="cols" gutterSize="16">
+  <mat-grid-tile *ngFor="let personagem of servico.bloqueados()">
+    <mat-card class="personagem-card">
+      <img mat-card-image [src]="personagem.image" [alt]="personagem.name" />
+      <mat-card-title>{{ personagem.name }}</mat-card-title>
+      <mat-card-subtitle>{{ personagem.status }}</mat-card-subtitle>
+      <mat-card-content>{{ personagem.species }}</mat-card-content>
+      <button
+        mat-button
+        color="primary"
+        (click)="desbloquear(personagem.id)"
+      >
+        Desbloquear
+      </button>
+    </mat-card>
+  </mat-grid-tile>
+</mat-grid-list>

--- a/src/app/personagens/lista-bloqueados/lista-bloqueados.component.scss
+++ b/src/app/personagens/lista-bloqueados/lista-bloqueados.component.scss
@@ -1,0 +1,5 @@
+.personagem-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}

--- a/src/app/personagens/lista-bloqueados/lista-bloqueados.component.spec.ts
+++ b/src/app/personagens/lista-bloqueados/lista-bloqueados.component.spec.ts
@@ -1,0 +1,34 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { RickAndMortyServico } from '../rick-and-morty.servico';
+import { ListaBloqueadosComponent } from './lista-bloqueados.component';
+
+describe('ListaBloqueadosComponent', () => {
+  let component: ListaBloqueadosComponent;
+  let fixture: ComponentFixture<ListaBloqueadosComponent>;
+  let servico: RickAndMortyServico;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, RouterTestingModule, ListaBloqueadosComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ListaBloqueadosComponent);
+    component = fixture.componentInstance;
+    servico = TestBed.inject(RickAndMortyServico);
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display bloqueados', () => {
+    servico.bloqueados.set([{ id: 1, name: 'Rick', status: '', species: 'Human', image: '', bloqueado: true }]);
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Rick');
+  });
+});

--- a/src/app/personagens/lista-bloqueados/lista-bloqueados.component.ts
+++ b/src/app/personagens/lista-bloqueados/lista-bloqueados.component.ts
@@ -1,0 +1,45 @@
+import { Component, HostListener, OnInit, inject, PLATFORM_ID } from '@angular/core';
+import { CommonModule, isPlatformBrowser } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+import { MatGridListModule } from '@angular/material/grid-list';
+import { MatButtonModule } from '@angular/material/button';
+import { RickAndMortyServico } from '../rick-and-morty.servico';
+import { Personagem } from '../personagem.model';
+
+@Component({
+  selector: 'app-lista-bloqueados',
+  standalone: true,
+  imports: [CommonModule, RouterLink, MatCardModule, MatGridListModule, MatButtonModule],
+  templateUrl: './lista-bloqueados.component.html',
+  styleUrls: ['./lista-bloqueados.component.scss'],
+})
+export class ListaBloqueadosComponent implements OnInit {
+  cols = 4;
+  private readonly platformId = inject(PLATFORM_ID);
+
+  constructor(public servico: RickAndMortyServico) {}
+
+  @HostListener('window:resize')
+  onResize() {
+    if (isPlatformBrowser(this.platformId)) {
+      this.setCols(window.innerWidth);
+    }
+  }
+
+  private setCols(width: number) {
+    this.cols = width < 600 ? 2 : 4;
+  }
+
+  ngOnInit() {
+    if (isPlatformBrowser(this.platformId)) {
+      this.setCols(window.innerWidth);
+    }
+  }
+
+  desbloquear(id: number) {
+    if (confirm('Desbloquear personagem?')) {
+      this.servico.desbloquearPersonagem(id);
+    }
+  }
+}

--- a/src/app/personagens/lista-personagens/lista-personagens.component.html
+++ b/src/app/personagens/lista-personagens/lista-personagens.component.html
@@ -23,10 +23,9 @@
       <button
         mat-button
         color="warn"
-        *ngIf="personagem.id >= 10000"
-        (click)="excluir(personagem.id); $event.stopPropagation()"
+        (click)="excluir(personagem); $event.stopPropagation()"
       >
-        Excluir
+        {{ personagem.id >= 10000 ? 'Excluir' : 'Bloquear' }}
       </button>
     </mat-card>
   </mat-grid-tile>

--- a/src/app/personagens/lista-personagens/lista-personagens.component.ts
+++ b/src/app/personagens/lista-personagens/lista-personagens.component.ts
@@ -73,9 +73,13 @@ export class ListaPersonagensComponent implements OnInit {
     this.router.navigate(['/editar', id]);
   }
 
-  excluir(id: number) {
+  excluir(personagem: Personagem) {
     if (confirm('Excluir personagem?')) {
-      this.servico.removerPersonagem(id);
+      if (personagem.id >= 10000) {
+        this.servico.removerPersonagem(personagem.id);
+      } else {
+        this.servico.bloquearPersonagem(personagem);
+      }
     }
   }
 }

--- a/src/app/personagens/personagem.model.ts
+++ b/src/app/personagens/personagem.model.ts
@@ -11,4 +11,5 @@ export interface Personagem {
   episode?: string[];
   url?: string;
   created?: string;
+  bloqueado?: boolean;
 }

--- a/src/app/personagens/rick-and-morty.servico.spec.ts
+++ b/src/app/personagens/rick-and-morty.servico.spec.ts
@@ -76,4 +76,26 @@ describe('RickAndMortyServico', () => {
 
     expect(service.todos().length).toBe(0);
   });
+
+  it('should block and unblock personagens', () => {
+    const personagem: Personagem = {
+      id: 3,
+      name: 'Jerry',
+      status: 'Alive',
+      species: 'Human',
+      image: ''
+    };
+
+    service.bloquearPersonagem(personagem);
+    const blockReq = httpMock.expectOne('/api/bloqueados');
+    blockReq.flush({ ...personagem, bloqueado: true });
+
+    expect(service.bloqueados().length).toBe(1);
+
+    service.desbloquearPersonagem(personagem.id);
+    const unblockReq = httpMock.expectOne(`/api/bloqueados/${personagem.id}`);
+    unblockReq.flush({});
+
+    expect(service.bloqueados().length).toBe(0);
+  });
 });

--- a/src/app/shared/toolbar/toolbar.component.html
+++ b/src/app/shared/toolbar/toolbar.component.html
@@ -14,4 +14,8 @@
     <mat-icon>add</mat-icon>
     <span class="hide-mobile">Novo Personagem</span>
   </button>
+  <button mat-raised-button [routerLink]="['/bloqueados']">
+    <mat-icon>block</mat-icon>
+    <span class="hide-mobile">Bloqueados</span>
+  </button>
 </mat-toolbar>


### PR DESCRIPTION
## Summary
- allow tracking blocked characters in the service
- add blocked character list component and route
- update toolbar with a link to blocked characters
- support blocking API characters from the list
- extend unit tests for new functionality
- store blocked data in `db.json`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842674aef4c832cb2b255cdcf19719a