### PR TITLE
Fix Jest config for Angular project

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,22 +3,19 @@ const { compilerOptions } = require('./tsconfig');
 
 module.exports = {
   preset: 'jest-preset-angular',
+  testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/src/setup-jest.ts'],
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      stringifyContentPathRegex: '\\.html$',
-    },
-  },
+
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths || {}, {
     prefix: '<rootDir>/',
   }),
+
   transform: {
-    '^.+\\.(ts|js|html)$': 'ts-jest',
+    '^.+\\.(ts|js|mjs|html|svg)$': 'jest-preset-angular'
   },
-  testEnvironment: 'jsdom',
-  moduleFileExtensions: ['ts', 'html', 'js', 'json'],
-  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+
+  moduleFileExtensions: ['ts', 'html', 'js', 'json', 'mjs'],
+  transformIgnorePatterns: ['node_modules/(?!(.*\\.mjs$))'],
   collectCoverage: true,
   coverageReporters: ['html', 'text'],
 };

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
     "module": "commonjs",
-    "types": ["jest"]
+    "types": ["jest", "node"]
   },
   "files": ["src/setup-jest.ts"],
   "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]


### PR DESCRIPTION
## Summary
- simplify Jest configuration by relying on `jest-preset-angular`
- ensure `setup-jest.ts` is used
- update `tsconfig.spec.json` compiler types

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684268958f64832c96f40d08eb12d3be