### PR TITLE
Add image type change handler

### DIFF
--- a/src/app/personagens/form-personagem/form-personagem.component.html
+++ b/src/app/personagens/form-personagem/form-personagem.component.html
@@ -29,7 +29,11 @@
 
     <mat-form-field appearance="fill">
       <mat-label>Tipo de Imagem</mat-label>
-      <mat-select [(ngModel)]="imageInputType" name="imageType">
+      <mat-select
+        [(ngModel)]="imageInputType"
+        name="imageType"
+        (selectionChange)="onImageTypeChange()"
+      >
         <mat-option value="url">URL</mat-option>
         <mat-option value="file">Arquivo</mat-option>
       </mat-select>

--- a/src/app/personagens/form-personagem/form-personagem.component.ts
+++ b/src/app/personagens/form-personagem/form-personagem.component.ts
@@ -47,6 +47,10 @@ export class FormPersonagemComponent implements OnInit {
   editMode = false;
   imageInputType: 'url' | 'file' = 'url';
 
+  onImageTypeChange() {
+    this.form.controls.image.setValue('');
+  }
+
   constructor(
     private fb: FormBuilder,
     private servico: RickAndMortyServico,


### PR DESCRIPTION
## Summary
- add a method to clear the image field when switching between URL or file
- hook the method into the image type selector

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68426a8be788832c9f1691db99f51c1a