### PR TITLE
Fix docs for missing Jest dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ is missing, install it with:
 npm install zone.js
 ```
 
+Jest also requires `@angular/platform-browser-dynamic`. If it is missing after
+installing dependencies, add it with:
+
+```bash
+npm install @angular/platform-browser-dynamic
+```
+
 ## Running Tests
 
 Execute unit tests with Jest:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@angular/forms": "^20.0.0",
     "@angular/material": "^20.0.2",
     "@angular/platform-browser": "^20.0.0",
+    "@angular/platform-browser-dynamic": "^20.0.0",
     "@angular/platform-server": "^20.0.0",
     "@angular/router": "^20.0.0",
     "@angular/ssr": "^20.0.1",


### PR DESCRIPTION
## Summary
- document missing `@angular/platform-browser-dynamic`
- add it to `package.json`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68427130d8e0832ca1e996588e135a61