### PR TITLE
Add blocking and dialog edit actions

### DIFF
--- a/src/app/personagens/form-personagem/form-personagem.component.ts
+++ b/src/app/personagens/form-personagem/form-personagem.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Optional } from '@angular/core';
+import { Component, OnInit, Optional, Inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
   FormBuilder,
@@ -9,7 +9,7 @@ import {
 } from '@angular/forms';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { MatDialogRef } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { RickAndMortyServico } from '../rick-and-morty.servico';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -56,7 +56,8 @@ export class FormPersonagemComponent implements OnInit {
     private servico: RickAndMortyServico,
     private router: Router,
     private route: ActivatedRoute,
-    @Optional() private dialogRef?: MatDialogRef<FormPersonagemComponent>
+    @Optional() private dialogRef?: MatDialogRef<FormPersonagemComponent>,
+    @Optional() @Inject(MAT_DIALOG_DATA) public data?: Personagem
   ) {
     this.form = this.fb.nonNullable.group({
       id: 0,
@@ -71,18 +72,21 @@ export class FormPersonagemComponent implements OnInit {
   }
 
   ngOnInit() {
-    const id = this.route.snapshot.paramMap.get('id');
-    if (id) {
+    let personagem: Personagem | undefined = this.data;
+    if (!personagem) {
+      const id = this.route.snapshot.paramMap.get('id');
+      if (id) {
+        personagem = this.servico.localPersonagemById(+id);
+      }
+    }
+    if (personagem) {
       this.editMode = true;
-      const personagem = this.servico.localPersonagemById(+id);
-      if (personagem) {
-        this.form.patchValue({
-          ...personagem,
-          origin: personagem.origin?.name ?? '',
-        });
-        if (personagem.image?.startsWith('data:')) {
-          this.form.controls.imageType.setValue('file');
-        }
+      this.form.patchValue({
+        ...personagem,
+        origin: personagem.origin?.name ?? '',
+      });
+      if (personagem.image?.startsWith('data:')) {
+        this.form.controls.imageType.setValue('file');
       }
     }
   }

--- a/src/app/personagens/lista-personagens/lista-personagens.component.html
+++ b/src/app/personagens/lista-personagens/lista-personagens.component.html
@@ -19,8 +19,7 @@
       <button
         mat-button
         color="primary"
-        [routerLink]="['/editar', personagem.id]"
-        (click)="$event.stopPropagation()"
+        (click)="editar(personagem); $event.stopPropagation()"
         *ngIf="personagem.id >= 10000"
       >
         Editar
@@ -29,8 +28,16 @@
         mat-button
         color="warn"
         (click)="excluir(personagem); $event.stopPropagation()"
+        *ngIf="personagem.id >= 10000"
       >
-        {{ personagem.id >= 10000 ? 'Excluir' : 'Bloquear' }}
+        Excluir
+      </button>
+      <button
+        mat-button
+        color="warn"
+        (click)="bloquear(personagem); $event.stopPropagation()"
+      >
+        Bloquear
       </button>
     </mat-card>
   </mat-grid-tile>

--- a/src/app/personagens/lista-personagens/lista-personagens.component.ts
+++ b/src/app/personagens/lista-personagens/lista-personagens.component.ts
@@ -1,12 +1,13 @@
 import { Component, OnInit, HostListener, inject, PLATFORM_ID } from '@angular/core';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
-import { RouterLink, Router } from '@angular/router';
+import { RouterLink } from '@angular/router';
 import { MatCardModule } from '@angular/material/card';
 import { MatGridListModule } from '@angular/material/grid-list';
 import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { PersonagemDialogComponent } from '../personagem-dialog/personagem-dialog.component';
+import { FormPersonagemComponent } from '../form-personagem/form-personagem.component';
 import { Personagem } from '../personagem.model';
 
 import { RickAndMortyServico } from '../rick-and-morty.servico';
@@ -24,6 +25,7 @@ import { RickAndMortyServico } from '../rick-and-morty.servico';
     MatButtonModule,
     MatDialogModule,
     PersonagemDialogComponent,
+    FormPersonagemComponent,
   ],
 
   templateUrl: './lista-personagens.component.html',
@@ -37,7 +39,6 @@ export class ListaPersonagensComponent implements OnInit {
 
   constructor(
     public servico: RickAndMortyServico,
-    private router: Router,
     private dialog: MatDialog
   ) {}
 
@@ -69,17 +70,23 @@ export class ListaPersonagensComponent implements OnInit {
     });
   }
 
-  editar(id: number) {
-    this.router.navigate(['/editar', id]);
+  editar(personagem: Personagem) {
+    this.dialog.open(FormPersonagemComponent, {
+      data: personagem,
+    });
   }
 
   excluir(personagem: Personagem) {
     if (confirm('Excluir personagem?')) {
       if (personagem.id >= 10000) {
         this.servico.removerPersonagem(personagem.id);
-      } else {
-        this.servico.bloquearPersonagem(personagem);
       }
+    }
+  }
+
+  bloquear(personagem: Personagem) {
+    if (confirm('Bloquear personagem?')) {
+      this.servico.bloquearPersonagem(personagem);
     }
   }
 }

--- a/src/app/personagens/rick-and-morty.servico.ts
+++ b/src/app/personagens/rick-and-morty.servico.ts
@@ -15,10 +15,10 @@ export class RickAndMortyServico {
 
   todos = computed(() => {
     const filtro = this.filtro().toLowerCase();
-    const locais = this.locais().filter((p) =>
-      p.name.toLowerCase().includes(filtro)
-    );
     const bloqueadosIds = new Set(this.bloqueados().map((b) => b.id));
+    const locais = this.locais()
+      .filter((p) => !bloqueadosIds.has(p.id))
+      .filter((p) => p.name.toLowerCase().includes(filtro));
     const remotos = this.personagens()
       .filter((p) => !bloqueadosIds.has(p.id))
       .filter((p) => p.name.toLowerCase().includes(filtro));


### PR DESCRIPTION
## Summary
- allow filtering out blocked local characters
- show block, edit and delete actions on character cards
- open edit form in a dialog
- support editing via `MAT_DIALOG_DATA`

## Testing
- `npx tsc -p tsconfig.json`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842768d62f8832cb185de28c01caeda